### PR TITLE
Fix Thor task for Pro edition and bump tiny version number

### DIFF
--- a/lib/dradis/plugins/nmap/gem_version.rb
+++ b/lib/dradis/plugins/nmap/gem_version.rb
@@ -9,7 +9,7 @@ module Dradis
       module VERSION
         MAJOR = 3
         MINOR = 1
-        TINY = 1
+        TINY = 2
         PRE = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")

--- a/lib/tasks/thorfile.rb
+++ b/lib/tasks/thorfile.rb
@@ -6,37 +6,38 @@ class NmapTasks < Thor
   desc      "upload FILE", "upload the results of an Nmap scan"
   long_desc "Upload an Nmap scan to create nodes and notes for the hosts and "\
             "ports discovered during scanning."
+
   def upload(file_path)
     require 'config/environment'
+
+    logger = Logger.new(STDOUT)
+    logger.level = Logger::DEBUG
 
     unless File.exists?(file_path)
       $stderr.puts "** the file [#{file_path}] does not exist"
       exit(-1)
     end
 
+    content_service = nil
+    template_service = nil
+
+    template_service = Dradis::Plugins::TemplateService.new(plugin: Dradis::Plugins::Nmap)
+    if defined?(Dradis::Pro)
     # Set project scope from the PROJECT_ID env variable:
-    detect_and_set_project_scope if defined?(::Core::Pro)
+      detect_and_set_project_scope
+      content_service = Dradis::Pro::Plugins::ContentService.new(plugin: Dradis::Plugins::Nmap)
+    else
+      content_service = Dradis::Plugins::ContentService.new(plugin: Dradis::Plugins::Nmap)
+    end
 
-    plugin = Dradis::Plugins::Nmap
-
-    Dradis::Plugins::Nmap::Importer.new(
-      logger:           logger,
-      content_service:  service_namespace::ContentService.new(plugin: plugin),
-      template_service: Dradis::Plugins::TemplateService.new(plugin: plugin)
-    ).import(file: file_path)
+    importer = Dradis::Plugins::Nmap::Importer.new(
+                logger: logger,
+       content_service: content_service, 
+      template_service: template_service
+    )
+    
+    importer.import(file: file_path)
 
     logger.close
   end
-
-
-  private
-
-  def logger
-    @logger ||= Logger.new(STDOUT).tap { |l| l.level = Logger::DEBUG }
-  end
-
-  def service_namespace
-    defined?(Dradis::Pro) ? Dradis::Pro::Plugins : Dradis::Plugins
-  end
-
 end


### PR DESCRIPTION
Uploading an Nmap file in the command line on the Pro edition (through the Thor task) currently throws the following error: 

`uninitialized constant Dradis::Pro::Plugins::TemplateService (NameError)`

This fix resolves the error and also increases the tiny version number for the add-on