### PR TITLE
Fix exists? method compatibility issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gemspec
 # To use debugger
 # gem 'debugger'
 
-if Dir.exists?('../dradis-plugins')
+if Dir.exist?('../dradis-plugins')
   gem 'dradis-plugins', path: '../dradis-plugins'
 else
   gem 'dradis-plugins', github: 'dradis/dradis-plugins'

--- a/lib/tasks/thorfile.rb
+++ b/lib/tasks/thorfile.rb
@@ -10,7 +10,7 @@ class NmapTasks < Thor
   def upload(file_path)
     require 'config/environment'
 
-    unless File.exists?(file_path)
+    unless File.exist?(file_path)
       $stderr.puts "** the file [#{file_path}] does not exist"
       exit(-1)
     end


### PR DESCRIPTION
### Summary

This PR fixes the exists? method compatibility issue. Replace File.exists? and Dir.exists? with File.exist? and Dir.exist? where necessary.

### Check List

~~- [ ] Added a CHANGELOG entry~~
~~- [ ] Added specs~~
